### PR TITLE
Initial setup of Ansible role for 'crictl'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,58 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+---
+<!--- Verify first that your issue is not already reported on GitHub -->
+<!--- Also test if the latest release and devel branch are affected too -->
+<!--- Complete *all* sections as described, this form is processed automatically -->
+
+##### SUMMARY
+<!--- Explain the problem briefly below -->
+
+##### ISSUE TYPE
+- Bug Report
+
+
+##### ANSIBLE VERSION
+<!--- Paste verbatim output from "ansible --version" between quotes -->
+```paste below
+
+```
+
+##### CONFIGURATION
+<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
+```paste below
+
+```
+
+##### OS / ENVIRONMENT
+<!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
+
+
+##### STEPS TO REPRODUCE
+<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- HINT: You can paste gist.github.com links for larger files -->
+
+##### EXPECTED RESULTS
+<!--- Describe what you expected to happen when running the steps above -->
+
+
+##### ACTUAL RESULTS
+<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes -->
+```paste below
+
+```
+
+##### SCREENSHOTS
+<!--- If applicable, add screenshots to help explain your problem. -->
+
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+---
+
+<!--- Verify first that your feature was not already discussed on GitHub -->
+<!--- Complete *all* sections as described to the best of your knowledge -->
+
+##### SUMMARY
+<!--- Describe the new feature/improvement briefly below -->
+
+##### ISSUE TYPE
+- Feature Idea
+
+
+##### ADDITIONAL INFORMATION
+<!--- Describe how the feature would be used, why it is needed and what it would solve -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- HINT: You can also paste gist.github.com links for larger files -->

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,75 @@
+name: build-and-test
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'feature*'
+      - 'feature/*'
+      - 'feature_*'
+      - 'hotfix*'
+      - 'hotifx/*'
+      - 'master'
+  schedule:
+    - cron: '0 12 * * *'
+
+
+jobs:
+
+  code_quality:
+
+    name: SonarCloud Code Quality Check
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@v1
+      with:
+        path: 'darkwizard242.crictl'
+        fetch-depth: 0
+
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      with:
+        args: >
+          -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  build:
+
+    name: Build & Test
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 8
+      matrix:
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@v1
+      with:
+        path: 'darkwizard242.crictl'
+
+    - name: Set up Python 3.10.0
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.0
+
+    - name: Update repo cache, install python3-setuptools and required pip modules
+      run: |
+        sudo apt-get update
+        sudo apt-get install python3-setuptools -y
+        pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
+
+    - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      run: DISTRO=${{ matrix.IMAGE }} molecule test
+      env:
+        PY_COLORS: '1'
+        ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  release:
+
+    name: Release
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@v1
+      with:
+        path: 'darkwizard242.crictl'
+
+    - name: Set up Python 3.10.0
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.0
+
+    - name: Update repo cache, install python3-setuptools and required pip modules
+      run: |
+        sudo apt-get update
+        sudo apt-get install python3-setuptools -y
+        pip3 install -U pip wheel ansible
+
+    - name: Import to Ansible Galaxy.
+      run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+---
+extends: default
+
+ignore: |
+  .github/
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+[![build-test](https://github.com/darkwizard242/ansible-role-crictl/workflows/build-and-test/badge.svg?branch=master)](https://github.com/darkwizard242/ansible-role-crictl/actions?query=workflow%3Abuild-and-test) [![release](https://github.com/darkwizard242/ansible-role-crictl/workflows/release/badge.svg)](https://github.com/darkwizard242/ansible-role-crictl/actions?query=workflow%3Arelease) ![Ansible Role](https://img.shields.io/ansible/role/56889?color=dark%20green%20) ![Ansible Role](https://img.shields.io/ansible/role/d/56889?label=role%20downloads) ![Ansible Quality Score](https://img.shields.io/ansible/quality/56889?label=ansible%20quality%20score) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible-role-crictl&metric=alert_status)](https://sonarcloud.io/dashboard?id=ansible-role-crictl) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-role-crictl&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ansible-role-crictl) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-role-crictl&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ansible-role-crictl) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-role-crictl&metric=security_rating)](https://sonarcloud.io/dashboard?id=ansible-role-crictl) ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/darkwizard242/ansible-role-crictl?label=release) ![GitHub repo size](https://img.shields.io/github/repo-size/darkwizard242/ansible-role-crictl?color=orange&style=flat-square)
+
+# Ansible Role: crictl
+
+Role to install (_by default_) [crictl](https://github.com/kubernetes-sigs/cri-tools) on **Debian/Ubuntu** and **EL** systems. **crictl** is CLI tool for Kubernetes Container Runtime Interface.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below (located in `defaults/main.yml`):
+
+### Variables list:
+
+```yaml
+crictl_app: crictl
+crictl_version: 1.22.0
+crictl_os: linux
+crictl_arch: amd64
+crictl_dl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/{{ crictl_app }}-v{{ crictl_version }}-{{ crictl_os }}-{{ crictl_arch }}.tar.gz
+crictl_bin_path: /usr/local/bin
+crictl_file_owner: root
+crictl_file_group: root
+```
+
+### Variables table:
+
+Variable          | Description
+----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
+crictl_app        | Defines the app to install i.e. **crictl**
+crictl_version    | Defined to dynamically fetch the desired version to install. Defaults to: **1.22.0**
+crictl_os         | Defines os type.
+crictl_arch       | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
+crictl_dl_url     | Defines URL to download the crictl binary from.
+crictl_bin_path   | Defined to dynamically set the appropriate path to store crictl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+crictl_file_owner | Owner for the binary file of crictl.
+crictl_file_group | Group for the binary file of crictl.
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+For default behaviour of role (i.e. installation of **crictl**) in ansible playbooks.
+
+```yaml
+- hosts: servers
+  roles:
+    - darkwizard242.crictl
+```
+
+For customizing behavior of role (i.e. specifying the desired **crictl** version) in ansible playbooks.
+
+```yaml
+- hosts: servers
+  roles:
+    - darkwizard242.crictl
+  vars:
+    crictl_version: 1.21.0
+```
+
+For customizing behavior of role (i.e. placing binary of **crictl** package in different location) in ansible playbooks.
+
+```yaml
+- hosts: servers
+  roles:
+    - darkwizard242.crictl
+  vars:
+    crictl_bin_path: /bin/
+```
+
+## License
+
+[MIT](https://github.com/darkwizard242/ansible-role-crictl/blob/master/LICENSE)
+
+## Author Information
+
+This role was created by [Ali Muhammad](https://www.alimuhammad.dev/).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# defaults file for crictl
+
+crictl_app: crictl
+crictl_version: 1.22.0
+crictl_os: linux
+crictl_arch: amd64
+crictl_dl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/{{ crictl_app }}-v{{ crictl_version }}-{{ crictl_os }}-{{ crictl_arch }}.tar.gz
+crictl_bin_path: /usr/local/bin
+crictl_file_owner: root
+crictl_file_group: root

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,30 @@
+---
+galaxy_info:
+  role_name: crictl
+  author: darkwizard242
+  description: Installs/Uninstalls 'crictl', Kubernetes Container Runtime Interface.
+  company: none
+  license: MIT
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - crictl
+    - system
+    - os
+    - kubernetes
+    - container
+    - runtime

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: darkwizard242.crictl

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+    yamllint .
+    ansible-lint
+    flake8
+platforms:
+  - name: ${DISTRO:-ubuntu-18.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: true
+    privileged: true
+provisioner:
+  name: ansible
+  log: true
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+verifier:
+  name: testinfra
+  options:
+    verbose: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,30 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+PACKAGE_BINARY = '/usr/local/bin/crictl'
+
+
+def test_crictl_binary_exists(host):
+    """
+    Tests if crictl binary exists.
+    """
+    assert host.file(PACKAGE_BINARY).exists
+
+
+def test_crictl_binary_file(host):
+    """
+    Tests if crictl binary is a file type.
+    """
+    assert host.file(PACKAGE_BINARY).is_file
+
+
+def test_crictl_binary_which(host):
+    """
+    Tests the output to confirm crictl's binary location.
+    """
+    assert host.check_output('which crictl') == PACKAGE_BINARY

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=ansible-role-crictl
+sonar.organization=tech-overlord-github
+sonar.projectName=ansible-role-crictl
+sonar.coverage.exclusions=**/**
+sonar.python.version=3
+#sonar.projectVersion=$TRAVIS_JOB_ID
+
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://galaxy.ansible.com/darkwizard242/crictl
+sonar.links.ci=https://github.com/darkwizard242/ansible-role-crictl/actions
+sonar.links.scm=https://github.com/darkwizard242/ansible-role-crictl
+
+sonar.sources=.

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for crictl | Debian/Ubuntu Family
+
+- name: Debian/Ubuntu Family | Downloading and extracting {{ crictl_app }} {{ crictl_version }}
+  unarchive:
+    src: "{{ crictl_dl_url }}"
+    dest: "{{ crictl_bin_path }}"
+    owner: "{{ crictl_file_owner }}"
+    group: "{{ crictl_file_group }}"
+    extra_opts:
+      - crictl
+    remote_src: yes

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for crictl | EL Family
+
+- name: EL Family | Downloading and extracting {{ crictl_app }} {{ crictl_version }}
+  unarchive:
+    src: "{{ crictl_dl_url }}"
+    dest: "{{ crictl_bin_path }}"
+    owner: "{{ crictl_file_owner }}"
+    group: "{{ crictl_file_group }}"
+    extra_opts:
+      - crictl
+    remote_src: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for crictl
+
+- name: Import install_debian.yml if OS family is Debian
+  import_tasks: install_debian.yml
+  when: ansible_os_family == "Debian"
+
+- name: Import install_el.yml if OS family is EL
+  import_tasks: install_el.yml
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
* Installs `crictl` on Debian and EL Family systems.
* Performs code quality check.
* Runs TestInfra infrastructure test cases.
* Publishes to Ansible Galaxy.